### PR TITLE
feat(app.config): add support for `toc` & light/dark logo

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -46,5 +46,27 @@ export default defineAppConfig({
       target: '_blank',
       'aria-label': 'Nuxt UI on GitHub'
     }]
+  },
+  toc: {
+    title: 'Table of Contents',
+    bottom: {
+      title: 'Community',
+      links: [{
+        icon: 'i-heroicons-star',
+        label: 'Star on GitHub',
+        to: 'https://github.com/nuxt/ui',
+        target: '_blank',
+      }, {
+        icon: 'i-heroicons-book-open',
+        label: 'Nuxt UI Pro docs',
+        to: 'https://ui.nuxt.com/pro/guide',
+        target: '_blank',
+      }, {
+        icon: 'i-simple-icons-nuxtdotjs',
+        label: 'Purchase a license',
+        to: 'https://ui.nuxt.com/pro/purchase',
+        target: '_blank',
+      }]
+    }
   }
 })

--- a/app.config.ts
+++ b/app.config.ts
@@ -11,7 +11,12 @@ export default defineAppConfig({
   },
   header: {
     logo: {
-      src: ''
+      light: {
+        src: ''
+      },
+      dark: {
+        src: ''
+      }
     },
     search: true,
     colorMode: true,

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -4,13 +4,16 @@ import type { NavItem } from '@nuxt/content/dist/runtime/types'
 const navigation = inject<NavItem[]>('navigation', [])
 
 const { header } = useAppConfig()
+const colorMode = useColorMode()
+
+const logo = computed(() => colorMode.value === 'dark' ? header?.logo?.dark : header?.logo?.light)
 </script>
 
 <template>
   <UHeader>
     <template #logo>
-      <template v-if="header?.logo?.src">
-        <img v-bind="{ class: 'h-6 w-auto', ...header.logo }">
+      <template v-if="logo?.src">
+        <img v-bind="{ class: 'h-6 w-auto', ...logo }">
       </template>
       <template v-else>
         Nuxt UI Pro <UBadge label="Docs" variant="subtle" class="mb-0.5" />

--- a/content/1.getting-started/3.configuration.md
+++ b/content/1.getting-started/3.configuration.md
@@ -20,7 +20,7 @@ This template relies on a [catch-all route](https://nuxt.com/docs/guide/director
 
 ## App Configuration
 
-In addition to `@nuxt/ui-pro` configuration through the `app.config.ts`, this template lets you customize both `Header` and `Footer` components.
+In addition to `@nuxt/ui-pro` configuration through the `app.config.ts`, this template lets you customize the `Header`, `Footer` and the `Table of contents` components.
 
 ::tabs
   ::div
@@ -87,6 +87,41 @@ In addition to `@nuxt/ui-pro` configuration through the `app.config.ts`, this te
         target: '_blank',
         'aria-label': 'Nuxt UI on GitHub'
       }]
+    }
+  })
+  ```
+  ::
+
+  ::div
+  ---
+  label: Table of contents
+  ---
+
+  ```ts
+  export default defineAppConfig({
+    toc: {
+      // Title of the main table of contents
+      title: 'Table of Contents',
+      // Bottom TOC configuration
+      bottom: {
+        title: 'Community',
+        links: [{
+          icon: 'i-heroicons-star',
+          label: 'Star on GitHub',
+          to: 'https://github.com/nuxt/ui',
+          target: '_blank',
+        }, {
+          icon: 'i-heroicons-book-open',
+          label: 'Nuxt UI Pro docs',
+          to: 'https://ui.nuxt.com/pro/guide',
+          target: '_blank',
+        }, {
+          icon: 'i-simple-icons-nuxtdotjs',
+          label: 'Purchase a license',
+          to: 'https://ui.nuxt.com/pro/purchase',
+          target: '_blank',
+        }]
+      }
     }
   })
   ```

--- a/content/1.getting-started/3.configuration.md
+++ b/content/1.getting-started/3.configuration.md
@@ -33,9 +33,18 @@ In addition to `@nuxt/ui-pro` configuration through the `app.config.ts`, this te
     header: {
       // Logo configuration
       logo: {
-        src: '',
-        alt: '',
-        class: ''
+        // Light mode
+        light: {
+          src: '',
+          alt: '',
+          class: ''
+        },
+        // Dark mode
+        dark: {
+          src: '',
+          alt: '',
+          class: ''
+        }
       },
       // Show or hide the search bar 
       search: true,

--- a/nuxt.schema.ts
+++ b/nuxt.schema.ts
@@ -134,6 +134,41 @@ export default defineNuxtSchema({
           default: []
         })
       }
+    }),
+    toc: group({
+      title: 'Table of contents',
+      description: 'TOC configuration.',
+      icon: 'i-heroicons-table-cells-solid',
+      fields: {
+        title: field({
+          type: 'string',
+          title: 'Title',
+          description: 'Text to display as title of the main toc.',
+          icon: 'i-heroicons-pencil-square',
+          default: ''
+        }),
+        bottom: group({
+          title: 'Bottom',
+          description: 'Bottom TOC configuration.',
+          icon: 'i-heroicons-bars-arrow-down-solid',
+          fields: {
+            title: field({
+              type: 'string',
+              title: 'Title',
+              description: 'Text to display as title of the bottom toc.',
+              icon: 'i-heroicons-pencil-square',
+              default: ''
+            }),
+            links: field({
+              type: 'array',
+              title: 'Links',
+              description: 'Array of link object displayed in bottom toc.',
+              icon: 'i-mdi-link-variant',
+              default: []
+            })
+          }
+        })
+      }
     })
   }
 })

--- a/nuxt.schema.ts
+++ b/nuxt.schema.ts
@@ -68,20 +68,48 @@ export default defineNuxtSchema({
           description: 'Footer logo configuration.',
           icon: 'i-mdi-image-filter-center-focus-strong-outline',
           fields: {
-            src: field({
-              type: 'media',
-              title: 'Logo',
-              description: 'Pick an image from your gallery.',
-              icon: 'i-mdi-image',
-              default: ''
+            dark: group({
+              title: 'Dark',
+              description: 'Dark Mode Logo.',
+              icon: 'i-heroicons-moon-20-solid',
+              fields: {
+                src: field({
+                  type: 'media',
+                  title: 'Logo',
+                  description: 'Pick an image from your gallery.',
+                  icon: 'i-mdi-image',
+                  default: ''
+                }),
+                alt: field({
+                  type: 'string',
+                  title: 'Alt',
+                  description: 'Alt to display for accessibility.',
+                  icon: 'i-mdi-alphabet-latin',
+                  default: ''
+                })
+              }
             }),
-            alt: field({
-              type: 'string',
-              title: 'Alt',
-              description: 'Alt to display for accessibility.',
-              icon: 'i-mdi-alphabet-latin',
-              default: ''
-            })
+            light: group({
+              title: 'Light',
+              description: 'Light Mode Logo.',
+              icon: 'i-heroicons-sun-20-solid',
+              fields: {
+                src: field({
+                  type: 'media',
+                  title: 'Logo',
+                  description: 'Pick an image from your gallery.',
+                  icon: 'i-mdi-image',
+                  default: ''
+                }),
+                alt: field({
+                  type: 'string',
+                  title: 'Alt',
+                  description: 'Alt to display for accessibility.',
+                  icon: 'i-mdi-alphabet-latin',
+                  default: ''
+                })
+              }
+            }),
           }
         }),
         search: field({
@@ -95,7 +123,7 @@ export default defineNuxtSchema({
           type: 'boolean',
           title: 'Color Mode',
           description: 'Hide or display the color mode button in your header.',
-          icon: 'i-mdi-moon-waning-crescent',
+          icon: 'i-heroicons-moon-20-solid',
           default: true
         }),
         links: field({
@@ -123,7 +151,7 @@ export default defineNuxtSchema({
           type: 'boolean',
           title: 'Color Mode',
           description: 'Hide or display the color mode button in the footer.',
-          icon: 'i-mdi-moon-waning-crescent',
+          icon: 'i-heroicons-moon-20-solid',
           default: false
         }),
         links: field({

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -6,6 +6,7 @@ definePageMeta({
 })
 
 const route = useRoute()
+const { toc } = useAppConfig()
 
 const { data: page } = await useAsyncData(route.path, () => queryContent(route.path).findOne())
 if (!page.value) {
@@ -33,28 +34,6 @@ defineOgImage({
 })
 
 const headline = computed(() => findPageHeadline(page.value))
-
-const communityLinks = computed(() => [{
-  icon: 'i-heroicons-pencil-square',
-  label: 'Edit this page',
-  to: `https://github.com/nuxt-ui-pro/docs/edit/main/content/${page?.value?._file}`,
-  target: '_blank',
-}, {
-  icon: 'i-heroicons-star',
-  label: 'Star on GitHub',
-  to: 'https://github.com/nuxt/ui',
-  target: '_blank',
-}, {
-  icon: 'i-heroicons-book-open',
-  label: 'Nuxt UI Pro docs',
-  to: 'https://ui.nuxt.com/pro/guide',
-  target: '_blank',
-}, {
-  icon: 'i-simple-icons-nuxtdotjs',
-  label: 'Purchase a license',
-  to: 'https://ui.nuxt.com/pro/purchase',
-  target: '_blank',
-}])
 </script>
 
 <template>
@@ -70,12 +49,12 @@ const communityLinks = computed(() => [{
     </UPageBody>
 
     <template v-if="page.toc !== false" #right>
-      <UDocsToc :links="page.body?.toc?.links">
+      <UDocsToc :title="toc.title" :links="page.body?.toc?.links">
         <template #bottom>
           <div class="hidden lg:block space-y-6" :class="{ '!mt-6': page.body?.toc?.links?.length }">
             <UDivider v-if="page.body?.toc?.links?.length" type="dashed" />
 
-            <UPageLinks title="Community" :links="communityLinks" />
+            <UPageLinks v-if="toc?.bottom" :title="toc?.bottom.title" :links="toc?.bottom.links" />
           </div>
         </template>
       </UDocsToc>

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -34,6 +34,13 @@ defineOgImage({
 })
 
 const headline = computed(() => findPageHeadline(page.value))
+
+const links = computed(() => [{
+  icon: 'i-heroicons-pencil-square',
+  label: 'Edit this page',
+  to: `https://github.com/nuxt-ui-pro/docs/edit/main/content/${page?.value?._file}`,
+  target: '_blank',
+}, ...(toc?.bottom.links || [])])
 </script>
 
 <template>
@@ -50,11 +57,11 @@ const headline = computed(() => findPageHeadline(page.value))
 
     <template v-if="page.toc !== false" #right>
       <UDocsToc :title="toc.title" :links="page.body?.toc?.links">
-        <template #bottom>
+        <template v-if="toc.bottom" #bottom>
           <div class="hidden lg:block space-y-6" :class="{ '!mt-6': page.body?.toc?.links?.length }">
             <UDivider v-if="page.body?.toc?.links?.length" type="dashed" />
 
-            <UPageLinks v-if="toc?.bottom" :title="toc?.bottom.title" :links="toc?.bottom.links" />
+            <UPageLinks :title="toc.bottom.title" :links="links" />
           </div>
         </template>
       </UDocsToc>


### PR DESCRIPTION
New customization from `app.config.ts` with corresponding Nuxt Studio schema:
- Logo dark & light mode
- Table of content

Doc has been updated

https://github.com/nuxt-ui-pro/docs/assets/7290030/135a771f-3e3c-4fd5-8f92-e0d7e114c2ab



