### PR TITLE
feat(configs): site name customization

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -9,6 +9,9 @@ export default defineAppConfig({
       }
     }
   },
+  seo: {
+    siteName: 'Nuxt UI Pro - Docs template',
+  },
   header: {
     logo: {
       alt: '',

--- a/app.vue
+++ b/app.vue
@@ -22,7 +22,7 @@ useHead({
 })
 
 useSeoMeta({
-  ogSiteName: seo.siteName,
+  ogSiteName: seo?.siteName,
   twitterCard: 'summary_large_image'
 })
 

--- a/app.vue
+++ b/app.vue
@@ -2,6 +2,7 @@
 import type { ParsedContent } from '@nuxt/content/dist/runtime/types'
 
 const { seo } = useAppConfig()
+
 const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
 const { data: files } = useLazyFetch<ParsedContent[]>('/api/search.json', {
   default: () => [],

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ParsedContent } from '@nuxt/content/dist/runtime/types'
 
+const { seo } = useAppConfig()
 const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
 const { data: files } = useLazyFetch<ParsedContent[]>('/api/search.json', {
   default: () => [],
@@ -20,7 +21,7 @@ useHead({
 })
 
 useSeoMeta({
-  ogSiteName: 'Nuxt UI Pro - Docs template',
+  ogSiteName: seo.siteName,
   twitterCard: 'summary_large_image'
 })
 

--- a/nuxt.schema.ts
+++ b/nuxt.schema.ts
@@ -16,42 +16,42 @@ export default defineNuxtSchema({
               type: 'icon',
               title: 'Search Bar',
               description: 'Icon to display in the search bar.',
-              icon: 'i-heroicons-magnifying-glass-20-solid',
+              icon: 'i-mdi-magnify',
               default: 'i-heroicons-magnifying-glass-20-solid'
             }),
             dark: field({
               type: 'icon',
               title: 'Dark mode',
               description: 'Icon of color mode button for dark mode.',
-              icon: 'i-heroicons-moon-20-solid',
+              icon: 'i-mdi-moon-waning-crescent',
               default: 'i-heroicons-moon-20-solid'
             }),
             light: field({
               type: 'icon',
               title: 'Light mode',
               description: 'Icon of color mode button for light mode.',
-              icon: 'i-heroicons-sun-20-solid',
+              icon: 'i-mdi-white-balance-sunny',
               default: 'i-heroicons-sun-20-solid'
             }),
             external: field({
               type: 'icon',
               title: 'External Link',
               description: 'Icon for external link.',
-              icon: 'i-heroicons-arrow-up-right-20-solid',
+              icon: 'i-mdi-arrow-top-right',
               default: 'i-heroicons-arrow-up-right-20-solid'
             }),
             chevron: field({
               type: 'icon',
               title: 'Chevron',
               description: 'Icon for chevron.',
-              icon: 'i-heroicons-chevron-down-20-solid',
+              icon: 'i-mdi-chevron-down',
               default: 'i-heroicons-chevron-down-20-solid'
             }),
             hash: field({
               type: 'icon',
               title: 'Hash',
               description: 'Icon for hash anchors.',
-              icon: 'i-heroicons-hashtag-20-solid',
+              icon: 'i-ph-hash',
               default: 'i-heroicons-hashtag-20-solid'
             })
           }
@@ -74,6 +74,20 @@ export default defineNuxtSchema({
         })
       }
     }),
+    seo: group({
+      title: 'SEO',
+      description: 'SEO configuration.',
+      icon: 'i-ph-app-window',
+      fields: {
+        siteName: field({
+          type: 'string',
+          title: 'Site Name',
+          description: 'Name used in ogSiteName and used as second part of your page title (My page title - Nuxt UI Pro).',
+          icon: 'i-mdi-web',
+          default: []
+        })
+      },
+    }),
     header: group({
       title: 'Header',
       description: 'Header configuration.',
@@ -88,14 +102,14 @@ export default defineNuxtSchema({
               type: 'media',
               title: 'Light Mode Logo',
               description: 'Pick an image from your gallery.',
-              icon: 'i-heroicons-sun-20-solid',
+              icon: 'i-mdi-white-balance-sunny',
               default: ''
             }),
             dark: field({
               type: 'media',
               title: 'Dark Mode Logo',
               description: 'Pick an image from your gallery.',
-              icon: 'i-heroicons-moon-20-solid',
+              icon: 'i-mdi-moon-waning-crescent',
               default: ''
             }),
             alt: field({
@@ -118,7 +132,7 @@ export default defineNuxtSchema({
           type: 'boolean',
           title: 'Color Mode',
           description: 'Hide or display the color mode button in your header.',
-          icon: 'i-heroicons-moon-20-solid',
+          icon: 'i-mdi-moon-waning-crescent',
           default: true
         }),
         links: field({
@@ -146,7 +160,7 @@ export default defineNuxtSchema({
           type: 'boolean',
           title: 'Color Mode',
           description: 'Hide or display the color mode button in the footer.',
-          icon: 'i-heroicons-moon-20-solid',
+          icon: 'i-mdi-moon-waning-crescent',
           default: false
         }),
         links: field({
@@ -161,7 +175,7 @@ export default defineNuxtSchema({
     toc: group({
       title: 'Table of contents',
       description: 'TOC configuration.',
-      icon: 'i-heroicons-table-cells-solid',
+      icon: 'i-mdi-table-of-contents',
       fields: {
         title: field({
           type: 'string',
@@ -173,7 +187,7 @@ export default defineNuxtSchema({
         bottom: group({
           title: 'Bottom',
           description: 'Bottom TOC configuration.',
-          icon: 'i-heroicons-bars-arrow-down-solid',
+          icon: 'i-mdi-table-of-contents',
           fields: {
             title: field({
               type: 'string',
@@ -186,7 +200,7 @@ export default defineNuxtSchema({
               type: 'string',
               title: 'Edit Page Link',
               description: 'URL of your repository content folder.',
-              icon: 'i-heroicons-pencil-square',
+              icon: 'i-ph-note-pencil',
               default: ''
             }),
             links: field({

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -22,7 +22,7 @@ const { data: surround } = await useAsyncData(`${route.path}-surround`, () => qu
 useSeoMeta({
   titleTemplate: `%s - ${seo?.siteName}`,
   title: page.value.title,
-  ogTitle: `${page.value.title} - Nuxt UI Pro - Docs template`,
+  ogTitle: `${page.value.title} - ${seo?.siteName}`,
   description: page.value.description,
   ogDescription: page.value.description
 })

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -6,7 +6,7 @@ definePageMeta({
 })
 
 const route = useRoute()
-const { toc } = useAppConfig()
+const { toc, seo } = useAppConfig()
 
 const { data: page } = await useAsyncData(route.path, () => queryContent(route.path).findOne())
 if (!page.value) {
@@ -20,7 +20,7 @@ const { data: surround } = await useAsyncData(`${route.path}-surround`, () => qu
 )
 
 useSeoMeta({
-  titleTemplate: '%s - Nuxt UI Pro - Docs template',
+  titleTemplate: `%s - ${seo?.siteName}`,
   title: page.value.title,
   ogTitle: `${page.value.title} - Nuxt UI Pro - Docs template`,
   description: page.value.description,


### PR DESCRIPTION
- Add siteName configuration for Studio users.
- Use `mdi` or `ph` collections for Studio icons (heroicons has been removed from studio collections)