### PR TITLE
chore(nuxt.config): set `UIcon` component as global

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
   hooks: {
     // Define `@nuxt/ui` components as global to use them in `.md` (feel free to add those you need)
     'components:extend': (components) => {
-      const globals = components.filter((c) => ['UButton'].includes(c.pascalName))
+      const globals = components.filter((c) => ['UButton', 'UIcon'].includes(c.pascalName))
 
       globals.forEach((c) => c.global = true)
     }


### PR DESCRIPTION
For Studio users, it's convenient to have `UIcon` as a component suggestion.

<img width="836" alt="Screenshot 2024-01-11 at 17 43 58" src="https://github.com/nuxt-ui-pro/docs/assets/7290030/752271a5-b450-4db1-9c24-5651692e4a69">

@Atinux I think we should even hide the `icon` component from nuxt-icon if `UIcon` is detected since UIcon set with the `dynamic` prop IS an `icon`. WDYT ? 