### PR TITLE
fix: workaround for Nuxt prerender regression

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,6 +17,10 @@ export default defineNuxtConfig({
       globals.forEach(c => c.global = true)
     }
   },
+  // Temporary workaround for prerender regression. see https://github.com/nuxt/nuxt/issues/27490
+  routeRules: {
+    '/': { prerender: true }
+  },
   ui: {
     icons: ['heroicons', 'simple-icons']
   },


### PR DESCRIPTION
There is a regression in latest releases of Nuxt which prevent home page from pre-rendering, thus the static generation does not work well.