### PR TITLE
docs: fix init template branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Quick Start
 
 ```bash [Terminal]
-npx nuxi init -t github:nuxt-ui-pro/docs
+npx nuxi init -t github:nuxt-ui-pro/docs#v3
 ```
 
 ## Setup


### PR DESCRIPTION
Feel free to close this, but as I was testing the templates the `v1` was getting initialized instead of `v3` branch